### PR TITLE
Rename all "CV" to "Resume"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .venv/
 .env
 CVs/
+Resumes/
 __pycache__/
 log/
 resume/

--- a/mail.py
+++ b/mail.py
@@ -7,7 +7,7 @@ from email.utils import COMMASPACE, formatdate
 
 from envs import GMAIL_APP_PASSWORD
 
-def send_mail(send_from = "m.mohammadi.cie@gmail.com", send_to=["zumudcorporation@gmail.com"], subject="TestTailoredCV", text="This is a test email!", files=None, server="smtp.gmail.com", port=465):
+def send_mail(send_from = "m.mohammadi.cie@gmail.com", send_to=["zumudcorporation@gmail.com"], subject="TestTailoredResume", text="This is a test email!", files=None, server="smtp.gmail.com", port=465):
     assert isinstance(send_to, list)
 
     msg = MIMEMultipart()

--- a/models/templates.py
+++ b/models/templates.py
@@ -699,19 +699,19 @@ mteck_resume = r"""
 
 # Define name of classes
 class ResumeTemplate(str, Enum):
-  Blue_Modern_CV = "Blue Modern CV"
-  One_page_Simple_CV = "One_page Simple CV"
+  Blue_Modern_Resume = "Blue Modern CV"
+  One_page_Simple_Resume = "One_page Simple CV"
   MTeck_resume = "MTeck's Resume"
 
 # Define details of classes
 Template_Details = {
-  ResumeTemplate.Blue_Modern_CV: {
+  ResumeTemplate.Blue_Modern_Resume: {
     'num_pages': 2,
     'structure': template_1,
     'compiler': 'xelatex',
     'version': 'texlive2020'
   },
-  ResumeTemplate.One_page_Simple_CV: {
+  ResumeTemplate.One_page_Simple_Resume: {
     'num_pages': 1,
     'structure': template_2,
     'compiler': 'pdflatex',

--- a/openai_wrapper.py
+++ b/openai_wrapper.py
@@ -28,7 +28,7 @@ class TailoredResume(BaseModel):
 class TailoredCoverLetter(BaseModel):
     tailored_coverletter: str
 
-class CustomizedCV(BaseModel):
+class CustomizedResume(BaseModel):
     customized_resume: str
 
 class TailoredCL(BaseModel):
@@ -40,7 +40,7 @@ class CompanyName(BaseModel):
 class TailoredAnswer(BaseModel):
     tailored_answer: str
 
-def create_customized_cv(resume_text: str, job_description_text: str, model=AIModel.gpt_4o_mini):
+def create_customized_resume(resume_text: str, job_description_text: str, model=AIModel.gpt_4o_mini):
     completion = client.beta.chat.completions.parse(
         model=model,
         messages=[
@@ -57,11 +57,11 @@ def create_customized_cv(resume_text: str, job_description_text: str, model=AIMo
              Resume LaTeX:""" + resume_text},
             {"role": "user", "content": "Job description: "+job_description_text}
         ],
-        response_format=CustomizedCV  # ensures the out put is a json with the given format. For unsupported models, we can use JSON mode. read here: https://platform.openai.com/docs/guides/structured-outputs/json-mode
+        response_format=CustomizedResume  # ensures the out put is a json with the given format. For unsupported models, we can use JSON mode. read here: https://platform.openai.com/docs/guides/structured-outputs/json-mode
     )
 
-    ai_tailored_cv_response, = json.loads(completion.choices[0].message.content).values()  # create the json object and unpack
-    return ai_tailored_cv_response
+    ai_tailored_resume_response, = json.loads(completion.choices[0].message.content).values()  # create the json object and unpack
+    return ai_tailored_resume_response
 
 
 def create_customized_cl(resume_text: str, job_description_text: str, model=AIModel.gpt_4o_mini):
@@ -123,7 +123,7 @@ def consider_suitability(job_description: str, preferences: str, model: AIModel 
     logger.debug(f"Reason of eligibility desicion: {reason}")
     return suitability, reason
 
-def create_tailored_plain_resume(resume: str, job_description: str, model=AIModel.gpt_4o_mini, template=ResumeTemplate.Blue_Modern_CV) -> str:
+def create_tailored_plain_resume(resume: str, job_description: str, model=AIModel.gpt_4o_mini, template=ResumeTemplate.Blue_Modern_Resume) -> str:
     completion = client.beta.chat.completions.parse(
         model=model,
         messages=[
@@ -133,10 +133,10 @@ def create_tailored_plain_resume(resume: str, job_description: str, model=AIMode
         response_format=TailoredResume
     )
     tailored_resume = json.loads(completion.choices[0].message.content)["tailored_resume"]
-    logger.debug(f"The tailored CV plain text is: {tailored_resume}")
+    logger.debug(f"The tailored resume plain text is: {tailored_resume}")
     return tailored_resume
 
-def covert_plain_resume_to_latex(current_time: str, company_name: str, plain_resume: str, model=AIModel.gpt_4o_mini, template=ResumeTemplate.Blue_Modern_CV):
+def covert_plain_resume_to_latex(current_time: str, company_name: str, plain_resume: str, model=AIModel.gpt_4o_mini, template=ResumeTemplate.Blue_Modern_Resume):
 
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
@@ -150,7 +150,7 @@ def covert_plain_resume_to_latex(current_time: str, company_name: str, plain_res
             response_format=TailoredResume
         )
         tailored_resume = json.loads(completion.choices[0].message.content)["tailored_resume"]
-        logger.debug(f"The tailored CV Latex code in iteration {i} is: {tailored_resume}")
+        logger.debug(f"The tailored resume Latex code in iteration {i} is: {tailored_resume}")
         trimed_tailored_resume = tailored_resume[tailored_resume.find(r"\documentclass"):tailored_resume.rfind(r"\end{document}")+len(r"\end{document}")]  # removes possible extra things that AI adds
         created_tar_file = generate_tex_and_tar(current_time, company_name, trimed_tailored_resume, TEX_FILE_NAME, TAR_FOLDER_NAME)
         with open(created_tar_file, 'rb') as tar_file:

--- a/tests/test_CV.py
+++ b/tests/test_CV.py
@@ -71,13 +71,13 @@ class TestCreateTailoredPlainResume:
                 resume=sample_resume,
                 job_description=sample_job_description,
                 model=AIModel.gpt_4o_mini,
-                template=ResumeTemplate.Blue_Modern_CV
+                template=ResumeTemplate.Blue_Modern_Resume
             )
             
             # Verify results
-            # Test whether the output CV is string or not
+            # Test whether the output resume is string or not
             assert isinstance(result, str)
-            # Test whether the output CV contains tailored information
+            # Test whether the output resume contains tailored information
             assert "Senior Software Engineer" in result
             assert "Tech Corp" in result
 
@@ -142,10 +142,10 @@ class TestCreateTailoredPlainResume:
             assert "API Error" in str(exc_info.value)
 
 # Integration tests for the GET endpoint
-class TestTailoredCVEndpoint:
+class TestTailoredResumeEndpoint:
     def test_successful_request(self, sample_resume, sample_job_description, mock_tailored_resume):
-        with patch('openai_wrapper.create_tailored_plain_resume') as mock_create_cv:
-            mock_create_cv.return_value = mock_tailored_resume['tailored_resume']
+        with patch('openai_wrapper.create_tailored_plain_resume') as mock_create_resume:
+            mock_create_resume.return_value = mock_tailored_resume['tailored_resume']
             
             response = client.get(
                 "/generate-tailored-plain-resume",
@@ -172,7 +172,7 @@ class TestTailoredCVEndpoint:
                 "resume": sample_resume,
                 "job_description": sample_job_description,
                 "model": "invalid_model",
-                "template": ResumeTemplate.Blue_Modern_CV.value
+                "template": ResumeTemplate.Blue_Modern_Resume.value
             }
         )
         # Test whether request gives error when it is given invalid model

--- a/utils.py
+++ b/utils.py
@@ -17,7 +17,7 @@ def generate_tex_and_tar(current_time: str, company_name: str, latex_content: st
     """
     try:
         # Path of a folder for saving .tex files
-        resume_folder_path = f'./CVs/{current_time}_{company_name}'
+        resume_folder_path = f'./Resumes/{current_time}_{company_name}'
 
         # Path of .tar file
         tar_path = f'./CVs/{current_time}_{company_name}'
@@ -53,13 +53,13 @@ def generate_pdf(company_name: str, tailored_plain_resume: str, tailoring_option
     current_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
     # Make a folder for each job description to save PDF, .tex, and .tar files of tailored resume.
-    os.makedirs(f'./CVs/{current_time}_{company_name}', exist_ok=True)
+    os.makedirs(f'./Resumes/{current_time}_{company_name}', exist_ok=True)
 
     latex_compiler_response, _ = openai_wrapper.covert_plain_resume_to_latex(
         current_time, company_name, tailored_plain_resume, tailoring_options.ai_model, tailoring_options.resume_template
     )
     # Path to save pdf file of tailored resume
-    pdf_path = f'./CVs/{current_time}_{company_name}/{APPLICANT_NAME}_cv.pdf'
+    pdf_path = f'./Resumes/{current_time}_{company_name}/{APPLICANT_NAME}_resume.pdf'
     with open(pdf_path, 'wb') as f:
         f.write(latex_compiler_response.content)
     logger.debug(f"Generated resume saved at here: {pdf_path}")


### PR DESCRIPTION
CV is more of an academic term, since we are focused on jobseekers I renamed all CVs to Resumes